### PR TITLE
ramips: fix button definitions for Zyxel WSM20

### DIFF
--- a/target/linux/ramips/dts/mt7621_zyxel_wsm20.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_wsm20.dts
@@ -66,7 +66,7 @@
 		led {
 			label = "led";
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
-			linux,code = <BTN_0>;
+			linux,code = <KEY_LIGHTS_TOGGLE>;
 		};
 
 		reset {
@@ -78,7 +78,7 @@
 		wps {
 			label = "wps";
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WLAN>;
+			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
 };


### PR DESCRIPTION
Setting the events of the WPS and LED buttons to the best matching values based from the documentation: https://openwrt.org/docs/guide-user/hardware/hardware.button#procd_buttons
