### PR TITLE
mediatek: GL-MT6000: Change LED colors

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-glinet-gl-mt6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-glinet-gl-mt6000.dts
@@ -13,9 +13,9 @@
 
 	aliases {
 		serial0 = &uart0;
-		led-boot = &led_white;
-		led-failsafe = &led_white;
-		led-running = &led_blue;
+		led-boot = &led_blue;
+		led-failsafe = &led_blue;
+		led-running = &led_white;
 		led-upgrade = &led_white;
 	};
 


### PR DESCRIPTION
Fine tuning PR: openwrt/openwrt#14355

As the only LED is using white in the stock firmware when the device is running and blue for the bootloader I suggest following changes:
 - Using blue for the BL and preinit+failsafe
 - White for normal operation (like the original FW) and sysupgrade

With this changes it's clear by looking to the LED in which operation mode the device is and a possible BL stuck can be seen easily.
